### PR TITLE
Don't update simulation index column if already present

### DIFF
--- a/R/add_sim_index_number.R
+++ b/R/add_sim_index_number.R
@@ -5,6 +5,9 @@
 #' @param id character specifying the column name in the data.frame
 #' @export
 add_sim_index_number <- function (sim, id = "id") { # for multiple simulations in a single dataframe, add an index number for every simulation
+  if ("sim" %in% colnames(sim)) {   # Keep simulation index column if already present
+      return(sim$sim)
+  }
   sim[[id]] <- as.num(sim[[id]])
   sim_id <- unique(sim[[id]])
   sim$id_shift <- c(sim[[id]][2:length(sim[[id]])], 0) 


### PR DESCRIPTION
I am doing some experiments with vpcs for mixture models using your package. I found a need to prespecify the simulation id hence my addition.

Best regards,
Rikard Nordgren
