### PR TITLE
Added scales to options

### DIFF
--- a/R/plot_vpc.R
+++ b/R/plot_vpc.R
@@ -149,24 +149,24 @@ plot_vpc <- function(db,
       if(is.null(db$labeller)) db$labeller <- ggplot2::label_both
       if(length(db$stratify) == 1) {
         if (db$facet == "wrap") {
-          pl <- pl + ggplot2::facet_wrap(stats::reformulate(db$stratify[1], NULL), 
+          pl <- pl + ggplot2::facet_wrap(stats::reformulate(db$stratify[1], NULL), scales = db$scales, 
                                          labeller = db$labeller)
         } else {
           if(length(grep("row", db$facet))>0) {
-            pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify[1], NULL),
+            pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify[1], NULL), scales = db$scales,
                                            labeller = db$labeller)
           } else {
-            pl <- pl + ggplot2::facet_grid(stats::reformulate(".", db$stratify[1]),
+            pl <- pl + ggplot2::facet_grid(stats::reformulate(".", db$stratify[1]), scales = db$scales,
                                            labeller = db$labeller)
           }
         }
       } else { # 2 grid-stratification
         if (db$stratify[1] %in% c(colnames(db$vpc_dat), colnames(db$aggr_obs))) {
           if(length(grep("row", db$facet))>0) {
-            pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify[1], db$stratify[2]),
+            pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify[1], db$stratify[2]), scales = db$scales,
                                            labeller = db$labeller)
           } else {
-            pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify[2], db$stratify[1]),
+            pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify[2], db$stratify[1]), scales = db$scales,
                                            labeller = db$labeller)
           }
         } else { # only color stratification
@@ -303,23 +303,23 @@ plot_vpc <- function(db,
       if (length(db$stratify_pars) == 1 | db$rtte) {
         if (db$facet == "wrap") {
           pl + ggplot2::facet_wrap(~sex)
-          pl <- pl + ggplot2::facet_wrap(stats::reformulate(db$stratify_pars[1], NULL),
+          pl <- pl + ggplot2::facet_wrap(stats::reformulate(db$stratify_pars[1], NULL), scales = db$scales, 
                                          labeller = db$labeller)
         } else {
           if(length(grep("row", db$facet)) > 0) {
-            pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify_pars[1], NULL),
+            pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify_pars[1], NULL), scales = db$scales,
                                            labeller = db$labeller)
           } else {
-            pl <- pl + ggplot2::facet_grid(stats::reformulate(".", db$stratify_pars[1]),
+            pl <- pl + ggplot2::facet_grid(stats::reformulate(".", db$stratify_pars[1]), scales = db$scales,
                                            labeller = db$labeller)
           }
         }
       } else {
         if(length(grep("row", db$facet)) > 0) {
-          pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify_pars[1], db$stratify_pars[2]),
+          pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify_pars[1], db$stratify_pars[2]), scales = db$scales, 
                                          labeller = db$labeller)
         } else {
-          pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify_pars[2], db$stratify_pars[1]),
+          pl <- pl + ggplot2::facet_grid(stats::reformulate(db$stratify_pars[2], db$stratify_pars[1]), scales = db$scales, 
                                          labeller = db$labeller)
         }
       }

--- a/R/vpc.R
+++ b/R/vpc.R
@@ -28,6 +28,7 @@
 #' @param smooth "smooth" the VPC (connect bin midpoints) or show bins as rectangular boxes. Default is TRUE.
 #' @param vpc_theme theme to be used in VPC. Expects list of class vpc_theme created with function vpc_theme()
 #' @param facet either "wrap", "columns", or "rows"
+#' @param scales either "fixed" (default), "free_y", "free_x" or "free"
 #' @param labeller ggplot2 labeller function to be passed to underlying ggplot object
 #' @param vpcdb Boolean whether to return the underlying vpcdb rather than the plot
 #' @param verbose show debugging information (TRUE or FALSE)
@@ -81,6 +82,7 @@ vpc_vpc <- function(sim = NULL,
                     smooth = TRUE,
                     vpc_theme = NULL,
                     facet = "wrap",
+                    scales = "fixed",
                     labeller = NULL,
                     vpcdb = FALSE,
                     verbose = FALSE, ...) {
@@ -116,7 +118,14 @@ vpc_vpc <- function(sim = NULL,
     }
     if(facet == "grid") facet <- "rows"
   }
-
+  ### Added by Satyaprakash Nayak ---
+  if(!is.null(scales)) {
+    if(! scales %in% c("fixed", "free_x", "free_y", "free")) {
+      stop("`scales` argument needs to be one of `fixed`, `free_y`, `free_x` or `free`.")
+    }
+    if(scales == "fixed") scales <- "fixed"
+  }
+  ###---
   ## software specific parsing, if necessary
   if (software_type == "PKPDsim") {
     if (!is.null(obs)) {
@@ -339,6 +348,7 @@ vpc_vpc <- function(sim = NULL,
                  obs = obs,
                  bins = bins,
                  facet = facet,
+                 scales = scales,       
                  labeller = labeller,
                  lloq = lloq,
                  uloq = uloq,

--- a/man/auto_bin.Rd
+++ b/man/auto_bin.Rd
@@ -8,9 +8,11 @@
 \usage{
 auto_bin(dat, type = "kmeans", n_bins = 8, verbose = FALSE, ...)
 
-\method{auto_bin}{numeric}(dat, type = "kmeans", n_bins = 8, verbose = FALSE, ...)
+\method{auto_bin}{numeric}(dat, type = "kmeans", n_bins = 8,
+  verbose = FALSE, ...)
 
-\method{auto_bin}{data.frame}(dat, type = "kmeans", n_bins = 8, verbose = FALSE, ...)
+\method{auto_bin}{data.frame}(dat, type = "kmeans", n_bins = 8,
+  verbose = FALSE, ...)
 }
 \arguments{
 \item{dat}{data frame}

--- a/man/check_stratification_columns_available.Rd
+++ b/man/check_stratification_columns_available.Rd
@@ -4,7 +4,8 @@
 \alias{check_stratification_columns_available}
 \title{Check whether stratification columns are available}
 \usage{
-check_stratification_columns_available(data, stratify, type = "observation")
+check_stratification_columns_available(data, stratify,
+  type = "observation")
 }
 \arguments{
 \item{data}{`data.frame` with observation or simulation data}

--- a/man/compute_kaplan.Rd
+++ b/man/compute_kaplan.Rd
@@ -4,13 +4,8 @@
 \alias{compute_kaplan}
 \title{Compute Kaplan-Meier statistics}
 \usage{
-compute_kaplan(
-  dat,
-  strat = "strat",
-  reverse_prob = FALSE,
-  rtte_conditional = TRUE,
-  ci = NULL
-)
+compute_kaplan(dat, strat = "strat", reverse_prob = FALSE,
+  rtte_conditional = TRUE, ci = NULL)
 }
 \arguments{
 \item{dat}{data.frame with events}

--- a/man/pk_iv_1cmt.Rd
+++ b/man/pk_iv_1cmt.Rd
@@ -4,15 +4,8 @@
 \alias{pk_iv_1cmt}
 \title{Simulate PK data from a 1-compartment iv model}
 \usage{
-pk_iv_1cmt(
-  t,
-  t_inf = 1,
-  tau = 24,
-  dose = 120,
-  CL = 0.345,
-  Vc = 1.75,
-  ruv = NULL
-)
+pk_iv_1cmt(t, t_inf = 1, tau = 24, dose = 120, CL = 0.345,
+  Vc = 1.75, ruv = NULL)
 }
 \arguments{
 \item{t}{Time after dose}

--- a/man/pk_oral_1cmt.Rd
+++ b/man/pk_oral_1cmt.Rd
@@ -4,7 +4,8 @@
 \alias{pk_oral_1cmt}
 \title{Simulate PK data from a 1-compartment oral model}
 \usage{
-pk_oral_1cmt(t, tau = 24, dose = 120, ka = 1, ke = 1, cl = 10, ruv = NULL)
+pk_oral_1cmt(t, tau = 24, dose = 120, ka = 1, ke = 1, cl = 10,
+  ruv = NULL)
 }
 \arguments{
 \item{t}{Time after dose}

--- a/man/plot_vpc.Rd
+++ b/man/plot_vpc.Rd
@@ -4,18 +4,9 @@
 \alias{plot_vpc}
 \title{VPC plotting function}
 \usage{
-plot_vpc(
-  db,
-  show = NULL,
-  vpc_theme = NULL,
-  smooth = TRUE,
-  log_x = FALSE,
-  log_y = FALSE,
-  xlab = NULL,
-  ylab = NULL,
-  title = NULL,
-  verbose = FALSE
-)
+plot_vpc(db, show = NULL, vpc_theme = NULL, smooth = TRUE,
+  log_x = FALSE, log_y = FALSE, xlab = NULL, ylab = NULL,
+  title = NULL, verbose = FALSE)
 }
 \arguments{
 \item{db}{object created using the `vpc` function}

--- a/man/read_table_nm.Rd
+++ b/man/read_table_nm.Rd
@@ -4,13 +4,8 @@
 \alias{read_table_nm}
 \title{NONMEM output table import function}
 \usage{
-read_table_nm(
-  file = NULL,
-  skip = NULL,
-  header = NULL,
-  rm_duplicates = FALSE,
-  nonmem_tab = TRUE
-)
+read_table_nm(file = NULL, skip = NULL, header = NULL,
+  rm_duplicates = FALSE, nonmem_tab = TRUE)
 }
 \arguments{
 \item{file}{full file name}

--- a/man/rtte_obs_nm.Rd
+++ b/man/rtte_obs_nm.Rd
@@ -4,9 +4,7 @@
 \name{rtte_obs_nm}
 \alias{rtte_obs_nm}
 \title{Simulated RTTE data (1x)}
-\format{
-An object of class \code{data.frame} with 573 rows and 6 columns.
-}
+\format{An object of class \code{data.frame} with 573 rows and 6 columns.}
 \usage{
 rtte_obs_nm
 }

--- a/man/rtte_sim_nm.Rd
+++ b/man/rtte_sim_nm.Rd
@@ -4,9 +4,7 @@
 \name{rtte_sim_nm}
 \alias{rtte_sim_nm}
 \title{Simulated RTTE data (100x)}
-\format{
-An object of class \code{data.frame} with 2000000 rows and 7 columns.
-}
+\format{An object of class \code{data.frame} with 2000000 rows and 7 columns.}
 \usage{
 rtte_sim_nm
 }

--- a/man/show_default.Rd
+++ b/man/show_default.Rd
@@ -4,9 +4,7 @@
 \name{show_default}
 \alias{show_default}
 \title{Defaults for show argument}
-\format{
-An object of class \code{list} of length 11.
-}
+\format{An object of class \code{list} of length 11.}
 \usage{
 show_default
 }

--- a/man/show_default_tte.Rd
+++ b/man/show_default_tte.Rd
@@ -4,9 +4,7 @@
 \name{show_default_tte}
 \alias{show_default_tte}
 \title{Defaults for show argument for TTE VPC}
-\format{
-An object of class \code{list} of length 11.
-}
+\format{An object of class \code{list} of length 11.}
 \usage{
 show_default_tte
 }

--- a/man/sim_data.Rd
+++ b/man/sim_data.Rd
@@ -4,17 +4,11 @@
 \alias{sim_data}
 \title{Simulate data based on a model and parameter distributions}
 \usage{
-sim_data(
-  design = cbind(id = c(1, 1, 1), idv = c(0, 1, 2)),
-  model = function(x) {     return(x$alpha + x$beta) },
-  theta,
-  omega_mat,
-  par_names,
-  par_values = NULL,
-  draw_iiv = "mvrnorm",
+sim_data(design = cbind(id = c(1, 1, 1), idv = c(0, 1, 2)),
+  model = function(x) {     return(x$alpha + x$beta) }, theta, omega_mat,
+  par_names, par_values = NULL, draw_iiv = "mvrnorm",
   error = list(proportional = 0, additive = 0, exponential = 0),
-  n = 100
-)
+  n = 100)
 }
 \arguments{
 \item{design}{a design dataset. See example}

--- a/man/simple_data.Rd
+++ b/man/simple_data.Rd
@@ -4,9 +4,7 @@
 \name{simple_data}
 \alias{simple_data}
 \title{A small rich dataset}
-\format{
-An object of class \code{list} of length 2.
-}
+\format{An object of class \code{list} of length 2.}
 \usage{
 simple_data
 }

--- a/man/vpc.Rd
+++ b/man/vpc.Rd
@@ -10,37 +10,15 @@ vpc(sim, ...)
 
 \method{vpc}{default}(sim, ...)
 
-vpc_vpc(
-  sim = NULL,
-  obs = NULL,
-  psn_folder = NULL,
-  bins = "jenks",
-  n_bins = "auto",
-  bin_mid = "mean",
-  obs_cols = NULL,
-  sim_cols = NULL,
-  software = "auto",
-  show = NULL,
-  stratify = NULL,
-  pred_corr = FALSE,
-  pred_corr_lower_bnd = 0,
-  pi = c(0.05, 0.95),
-  ci = c(0.05, 0.95),
-  uloq = NULL,
-  lloq = NULL,
-  log_y = FALSE,
-  log_y_min = 0.001,
-  xlab = NULL,
-  ylab = NULL,
-  title = NULL,
-  smooth = TRUE,
-  vpc_theme = NULL,
-  facet = "wrap",
-  labeller = NULL,
-  vpcdb = FALSE,
-  verbose = FALSE,
-  ...
-)
+vpc_vpc(sim = NULL, obs = NULL, psn_folder = NULL, bins = "jenks",
+  n_bins = "auto", bin_mid = "mean", obs_cols = NULL,
+  sim_cols = NULL, software = "auto", show = NULL, stratify = NULL,
+  pred_corr = FALSE, pred_corr_lower_bnd = 0, pi = c(0.05, 0.95),
+  ci = c(0.05, 0.95), uloq = NULL, lloq = NULL, log_y = FALSE,
+  log_y_min = 0.001, xlab = NULL, ylab = NULL, title = NULL,
+  smooth = TRUE, vpc_theme = NULL, facet = "wrap",
+  scales = "fixed", labeller = NULL, vpcdb = FALSE,
+  verbose = FALSE, ...)
 }
 \arguments{
 \item{sim}{this is usually a data.frame with observed data, containing the independent and dependent variable, a column indicating the individual, and possibly covariates. E.g. load in from NONMEM using \link{read_table_nm}.  However it can also be an object like a nlmixr or xpose object}
@@ -94,6 +72,8 @@ vpc_vpc(
 \item{vpc_theme}{theme to be used in VPC. Expects list of class vpc_theme created with function vpc_theme()}
 
 \item{facet}{either "wrap", "columns", or "rows"}
+
+\item{scales}{either "fixed" (default), "free_y", "free_x" or "free"}
 
 \item{labeller}{ggplot2 labeller function to be passed to underlying ggplot object}
 

--- a/man/vpc_cat.Rd
+++ b/man/vpc_cat.Rd
@@ -4,31 +4,12 @@
 \alias{vpc_cat}
 \title{VPC function for categorical}
 \usage{
-vpc_cat(
-  sim = NULL,
-  obs = NULL,
-  psn_folder = NULL,
-  bins = "jenks",
-  n_bins = "auto",
-  bin_mid = "mean",
-  obs_cols = NULL,
-  sim_cols = NULL,
-  software = "auto",
-  show = NULL,
-  ci = c(0.05, 0.95),
-  uloq = NULL,
-  lloq = NULL,
-  xlab = NULL,
-  ylab = NULL,
-  title = NULL,
-  smooth = TRUE,
-  vpc_theme = NULL,
-  facet = "wrap",
-  labeller = NULL,
-  plot = TRUE,
-  vpcdb = FALSE,
-  verbose = FALSE
-)
+vpc_cat(sim = NULL, obs = NULL, psn_folder = NULL, bins = "jenks",
+  n_bins = "auto", bin_mid = "mean", obs_cols = NULL,
+  sim_cols = NULL, software = "auto", show = NULL, ci = c(0.05,
+  0.95), uloq = NULL, lloq = NULL, xlab = NULL, ylab = NULL,
+  title = NULL, smooth = TRUE, vpc_theme = NULL, facet = "wrap",
+  labeller = NULL, plot = TRUE, vpcdb = FALSE, verbose = FALSE)
 }
 \arguments{
 \item{sim}{a data.frame with observed data, containing the independent and dependent variable, a column indicating the individual, and possibly covariates. E.g. load in from NONMEM using \link{read_table_nm}}

--- a/man/vpc_cens.Rd
+++ b/man/vpc_cens.Rd
@@ -4,33 +4,14 @@
 \alias{vpc_cens}
 \title{VPC function for left- or right-censored data (e.g. BLOQ data)}
 \usage{
-vpc_cens(
-  sim = NULL,
-  obs = NULL,
-  psn_folder = NULL,
-  bins = "jenks",
-  n_bins = 8,
-  bin_mid = "mean",
-  obs_cols = NULL,
-  sim_cols = NULL,
-  software = "auto",
-  show = NULL,
-  stratify = NULL,
-  stratify_color = NULL,
-  ci = c(0.05, 0.95),
-  uloq = NULL,
-  lloq = NULL,
-  plot = FALSE,
-  xlab = "Time",
-  ylab = "Probability of <LOQ",
-  title = NULL,
-  smooth = TRUE,
-  vpc_theme = NULL,
-  facet = "wrap",
-  labeller = NULL,
-  vpcdb = FALSE,
-  verbose = FALSE
-)
+vpc_cens(sim = NULL, obs = NULL, psn_folder = NULL, bins = "jenks",
+  n_bins = 8, bin_mid = "mean", obs_cols = NULL, sim_cols = NULL,
+  software = "auto", show = NULL, stratify = NULL,
+  stratify_color = NULL, ci = c(0.05, 0.95), uloq = NULL,
+  lloq = NULL, plot = FALSE, xlab = "Time",
+  ylab = "Probability of <LOQ", title = NULL, smooth = TRUE,
+  vpc_theme = NULL, facet = "wrap", labeller = NULL, vpcdb = FALSE,
+  verbose = FALSE)
 }
 \arguments{
 \item{sim}{a data.frame with observed data, containing the independent and dependent variable, a column indicating the individual, and possibly covariates. E.g. load in from NONMEM using \link{read_table_nm}}

--- a/man/vpc_tte.Rd
+++ b/man/vpc_tte.Rd
@@ -4,37 +4,15 @@
 \alias{vpc_tte}
 \title{VPC function for time-to-event (survival) data}
 \usage{
-vpc_tte(
-  sim = NULL,
-  obs = NULL,
-  psn_folder = NULL,
-  rtte = FALSE,
-  rtte_calc_diff = TRUE,
-  rtte_conditional = TRUE,
-  events = NULL,
-  bins = FALSE,
-  n_bins = 10,
-  software = "auto",
-  obs_cols = NULL,
-  sim_cols = NULL,
-  kmmc = NULL,
-  reverse_prob = FALSE,
-  stratify = NULL,
-  stratify_color = NULL,
-  ci = c(0.05, 0.95),
-  plot = FALSE,
-  xlab = "Time",
-  ylab = "Survival (\%)",
-  show = NULL,
-  as_percentage = TRUE,
-  title = NULL,
-  smooth = FALSE,
-  vpc_theme = NULL,
-  facet = "wrap",
-  labeller = NULL,
-  verbose = FALSE,
-  vpcdb = FALSE
-)
+vpc_tte(sim = NULL, obs = NULL, psn_folder = NULL, rtte = FALSE,
+  rtte_calc_diff = TRUE, rtte_conditional = TRUE, events = NULL,
+  bins = FALSE, n_bins = 10, software = "auto", obs_cols = NULL,
+  sim_cols = NULL, kmmc = NULL, reverse_prob = FALSE,
+  stratify = NULL, stratify_color = NULL, ci = c(0.05, 0.95),
+  plot = FALSE, xlab = "Time", ylab = "Survival (\%)", show = NULL,
+  as_percentage = TRUE, title = NULL, smooth = FALSE,
+  vpc_theme = NULL, facet = "wrap", labeller = NULL,
+  verbose = FALSE, vpcdb = FALSE)
 }
 \arguments{
 \item{sim}{a data.frame with observed data, containing the independent and dependent variable, a column indicating the individual, and possibly covariates. E.g. load in from NONMEM using \link{read_table_nm}}

--- a/tests/test-scales.R
+++ b/tests/test-scales.R
@@ -1,0 +1,16 @@
+library(vpc)
+library(testit)
+Sys.setenv("R_TESTS" = "")
+
+tmp <- simple_data
+sex <- (tmp$obs$ID) %% 2
+race <- (tmp$obs$ID) %% 3
+tmp$obs$sex <- sex
+tmp$obs$race <- race
+tmp$sim$sex <- sex
+tmp$sim$race <- race
+
+v1 <- vpc(sim = tmp$sim, obs = tmp$obs, stratify = "race",
+          facet = "wrap", scales = "free_y", vpcdb = F, labeller = ggplot2::label_both)
+assert("plot succeeded", "ggplot" %in% class(v1))
+assert("facets succeeded", vpc:::is_equal(length(v1$facet$params$facets), 1))


### PR DESCRIPTION
Hi Ron

I have added the ability to define scales for x and y-axis to be free or fixed for your review. I think this feature could be useful when the x or y is markedly different between facets (e.g., between single and multiple dose groups).

I have added a test file (test-scales.R) and checked that the figure with `scales = free_y` option makes the y-axis scale to be free. I also checked that the package passes CRAN checks with these additions. 

Thanks for the wonderful package!
Satya