### PR TITLE
Avoid underscored functions

### DIFF
--- a/R/compute_kmmc.R
+++ b/R/compute_kmmc.R
@@ -13,7 +13,7 @@ compute_kmmc <- function(dat, strat = NULL, reverse_prob = FALSE, kmmc = "DOSE")
     strats <- unique(dat[[strat]])
     tmp <- c()
     for (i in seq(strats)) {
-      summid <- dat %>% dplyr::group_by_("id") %>% dplyr::mutate(covt = mean(kmmc))
+      summid <- dat %>% dplyr::group_by(.data[["id"]]) %>% dplyr::mutate(covt = mean(kmmc))
       t <- unique(summid$time)
       km_fit <- data.frame(time = t[order(t)], surv=1)
       for (j in seq(km_fit$time)) {

--- a/R/functions.R
+++ b/R/functions.R
@@ -47,7 +47,7 @@ convert_to_dense_grid <- function(dat, t = "t", id = "id", t_start = 0, t_step =
   tmp$rtte <- 0
   tmp[match(id_t, paste0(tmp$id,"-",tmp$t)),]$rtte <- 1
   if (!is.null(add)) {
-    tmp2 <- merge(tmp, dat[,c("id", add)] %>% dplyr::group_by_("id") %>% dplyr::do(.[1,]), by = "id", all.y = FALSE)
+    tmp2 <- merge(tmp, dat[,c("id", add)] %>% dplyr::group_by(.data[["id"]]) %>% dplyr::do(.[1,]), by = "id", all.y = FALSE)
   }
   return(tmp2)
 }
@@ -68,11 +68,11 @@ relative_times <- function (dat, simulation = FALSE) {
 
 convert_from_dense_grid <- function (dat) {
   ## Note RK: only for a single trial, requires a loop or ddply for multiple subproblems
-  tmp <- dat %>% dplyr::group_by_("id")
+  tmp <- dat %>% dplyr::group_by(.data[["id"]])
   if("rtte" %in% names(dat)) {
     tmp <- tmp %>% dplyr::filter(rtte == 1)
   }
   tmp2 <- rbind(tmp %>% dplyr::filter(length(time) > 1) %>% dplyr::mutate(time = time - c(0,time[1:(length(time)-1)])),
                 tmp %>% dplyr::filter(length(time) == 1) )
-  return(tmp2 %>% dplyr::arrange_("id", "time"))
+  return(tmp2 %>% dplyr::arrange(.data[["id"]], .data[["time"]]))
 }


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package uses one of the "underscored" versions of a dplyr verb, such as `mutate_()` rather than `mutate()`. These were deprecated in 2017, and are now defunct and must be removed.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!